### PR TITLE
Reverting of '_' replacements in Infoblox record objects

### DIFF
--- a/pyinfoblox/__init__.py
+++ b/pyinfoblox/__init__.py
@@ -77,7 +77,7 @@ class InfobloxWAPI(object):
         # In order to use an Infoblox 'record' object replace the
         # colon character with underscore in your call, e.g. 'record_a'
         if 'record' in attr:
-            attr = attr.replace('_', ':')
+            attr = attr.replace('_', ':', 1)
 
         return InfobloxWAPIObject(
             objtype=attr,


### PR DESCRIPTION
For some record objects like entries like 'record:host_ipv4addr' the reverting the underscore replaces to much. Therefor it should be limited the first occurrence of '_'
