### PR TITLE
Use content-type:application/json and encode all data payloads

### DIFF
--- a/pyinfoblox/__init__.py
+++ b/pyinfoblox/__init__.py
@@ -61,6 +61,7 @@ class InfobloxWAPI(object):
         self.wapi = wapi
         self.session = requests.Session()
         self.session.auth = (self.username, self.password)
+        self.session.headers.update({'content-type': 'application/json'})
         self.session.verify = verify
 
     def __getattr__(self, attr):
@@ -114,7 +115,7 @@ class InfobloxWAPIObject(object):
             InfobloxWAPIException
 
         """
-        r = self.session.get(self.wapi + self.objtype, data=kwargs)
+        r = self.session.get(self.wapi + self.objtype, data=json.dumps(kwargs))
 
         if r.status_code != requests.codes.ok:
             raise InfobloxWAPIException(r.content)
@@ -132,7 +133,7 @@ class InfobloxWAPIObject(object):
             InfobloxWAPIException
 
         """
-        r = self.session.post(self.wapi + self.objtype, data=kwargs)
+        r = self.session.post(self.wapi + self.objtype, data=json.dumps(kwargs))
 
         if r.status_code != requests.codes.CREATED:
             raise InfobloxWAPIException(r.content)
@@ -192,7 +193,7 @@ class InfobloxWAPIObject(object):
             InfobloxWAPIException
 
         """
-        r = self.session.post(self.wapi + objref, data=kwargs)
+        r = self.session.post(self.wapi + objref, data=json.dumps(kwargs))
 
         if r.status_code != requests.codes.ok:
             raise InfobloxWAPIException(r.content)


### PR DESCRIPTION
Currently, the automatic selection for object creation doesn't work:

```python
infoblox.fixedaddress.create(ipv4addr='func:nextavailableip:192.168.1.0/24',
                             match_client='RESERVED')
```
This results in: Error converting argument ipv4addr: Invalid IPv4 address

This is because, as documented at https://ipam.illinois.edu/wapidoc/objects/fixedaddress.html#fixedaddress-ipv4addr:

> Automatic selection is supported only for JSON and XML requests.

So this PR explicitly uses content-type:application/json and encodes all of the data payloads as JSON. Incidentally this also resolves my final request in issue #2: to be able to set extensible attributes in the initial create call, as well as an update call.