### PR TITLE
When using GET requests, submit data as query params

### DIFF
--- a/pyinfoblox/__init__.py
+++ b/pyinfoblox/__init__.py
@@ -117,7 +117,7 @@ class InfobloxWAPIObject(object):
         """
         r = self.session.get(
             self.wapi + self.objtype,
-            data=json.dumps(kwargs)
+            params=kwargs
         )
 
         if r.status_code != requests.codes.ok:


### PR DESCRIPTION
As mentioned in #3, after switching the content-mode to application/json, the payload for GET requests needed to be sent as query params. Otherwise, this type of request will fail:

```python
infoblox.fixedaddress.get(
        ipv4addr='192.168.1.80', _return_fields='name,ipv4addr')
```