### PR TITLE
Fixes params vs data issues, adds support for objref form to get method.

### DIFF
--- a/pyinfoblox/__init__.py
+++ b/pyinfoblox/__init__.py
@@ -104,19 +104,20 @@ class InfobloxWAPIObject(object):
         self.wapi = wapi
         self.session = session
 
-    def get(self, **kwargs):
+    def get(self, objref=None, **kwargs):
         """
         Get Infoblox objects
 
         Returns:
-            A list of Infoblox objects
+            With objref, one Infoblox object,
+            in search form, a list of Infoblox objects
 
         Raises:
             InfobloxWAPIException
 
         """
         r = self.session.get(
-            self.wapi + self.objtype,
+            self.wapi + (objref if objref is not None else self.objtype),
             params=kwargs
         )
 

--- a/pyinfoblox/__init__.py
+++ b/pyinfoblox/__init__.py
@@ -136,8 +136,16 @@ class InfobloxWAPIObject(object):
             InfobloxWAPIException
 
         """
+        # Parameters with leading underscores are options, and
+        # must be sent as params, not data
+        params = {}
+        for k, v in kwargs.items():
+            if k.startswith('_'):
+                params[k] = kwargs.pop(k)
+
         r = self.session.post(
             self.wapi + self.objtype,
+            params=params,
             data=json.dumps(kwargs)
         )
 
@@ -160,8 +168,16 @@ class InfobloxWAPIObject(object):
             InfobloxWAPIException
 
         """
+        # Parameters with leading underscores are options, and
+        # must be sent as params, not data
+        params = {}
+        for k, v in kwargs.items():
+            if k.startswith('_'):
+                params[k] = kwargs.pop(k)
+
         r = self.session.put(
             self.wapi + objref,
+            params=params,
             data=json.dumps(kwargs)
         )
 
@@ -202,8 +218,16 @@ class InfobloxWAPIObject(object):
             InfobloxWAPIException
 
         """
+        # Parameters with leading underscores are options, and
+        # must be sent as params, not data
+        params = {}
+        for k, v in kwargs.items():
+            if k.startswith('_'):
+                params[k] = kwargs.pop(k)
+
         r = self.session.post(
             self.wapi + objref,
+            params=params,
             data=json.dumps(kwargs)
         )
 


### PR DESCRIPTION
POST calls that include functions must be in data, not params, but parameters such as _return_fields must be in params, not data. So this splits the kwargs into params and data, based on the fact that all params have a leading underscore.

As shown using `requests` directly:
```python
# This works, and we get the objref returned:
data = {'ipv4addr':'func:nextavailableip:192.168.10.0/24',
         'match_client':'RESERVED'}
r = session.post('https://infoblox/wapi/v1.4/fixedaddress', data=json.dumps(data))
print(r.content)

# But adding _return_fields causes it to fail:
data.update({'_return_fields':'ipv4addr'})
r = session.post('https://infoblox/wapi/v1.4/fixedaddress', data=json.dumps(data))
print(r.content)

# And switching to `params` doesn't work either, due to the func:nextavailableip call:
r = session.post('https://infoblox/wapi/v1.4/fixedaddress', params=data)
print(r.content)
```

Also, support was added to the get method for direct *objref* style, which returns a single object instead of a *objtype* list:

```python
>>> infoblox.fixedaddress.get(objref)
{u'_ref': u'fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTkyLjE2OC4xMC4xMC4wLi4:192.168.1.10/default',
 u'ipv4addr': u'192.168.1.10',
 u'network_view': u'default'}
```